### PR TITLE
Added keyboard/screen backlight options

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -5,9 +5,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	OFF = false
-)
 
 // resetCmd represents the reset command
 var resetCmd = &cobra.Command{
@@ -21,7 +18,7 @@ halp reset`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, _ := cmd.Flags().GetString("path")
-		return morse.UpdateState(path, OFF)
+		return morse.UpdateState(path, 0)
 	},
 }
 

--- a/morse/toggle.go
+++ b/morse/toggle.go
@@ -2,6 +2,7 @@ package morse
 
 import (
 	"os/exec"
+	"strconv"
 )
 
 // switch the capslock led off
@@ -13,17 +14,18 @@ func off(path string) error {
 }
 
 // switch the capslock led on
-func on(path string) error {
-	cmd := "echo 1 | sudo tee " + path
+func on(path string, brightness int) error {
+	cmd := "echo " + strconv.Itoa(brightness) + " | sudo tee " + path
 	err := exec.Command("bash", "-c", cmd).Run()
 
 	return err
 }
 
 // UpdateState updates the state of the capslock LED to on/off
-func UpdateState(path string, isOn bool) error {
-	if isOn {
-		return on(path)
+func UpdateState(path string, brightness int) error {
+	path = path + "/brightness"
+	if brightness > 0 {
+		return on(path, brightness)
 	}
 	return off(path)
 }


### PR DESCRIPTION
root:
        - Added 2 flags, -k and -s to use the keyboard or screen backlight instead
        - Walks through /sys/class/leds and regex matches the right backlight file
sos:
        - Added `getMaxBrightness` to determine the maximum brightness level
        - Added a `readFile` method which's used by `getInitialState` and `getMaxBrightness`
        - Used integer brightness levels instead of the original booleans
toggle:
        - Updated methods to take the brightness value as argument
Updated `UpdateState` calls to take the brightness values

Resolves #2 